### PR TITLE
Firestore reporter implementation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
 .dockerignore
 .git
 .gitignore
+*.log
 
 # default build name
 professor
+
+firebase.json
+firestore.rules

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ professor
 node_modules
 playwright-report
 test-results
+
+*.log

--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 Worker for the [Hack4Impact-UMD App Portal](apply.umd.hack4impact.org) assessment autograder.
 
+## Architecture
+
+```mermaid
+graph TB
+    User[Applicant] -->|Submits Assessment| Frontend[App Portal - Frontend]
+    Frontend[App Portal - Frontend] -->|Reads Status and Results| User[Applicant]
+    Frontend -->|Requests Grading| Backend[App Portal - Backend]
+
+    Backend -->|Creates Documents| Firestore[(Firestore)]
+    Backend -->|Enqueues Job| CloudTasks[Queue - Cloud Tasks]
+
+    CloudTasks -->|Delivers Job| Professor[Professor - Cloud Run]
+
+    Professor -->|Updates Documents| Firestore
+    Professor -->|Clones Repo| GitHub[GitHub]
+    Professor -->|Tests Repo| Playwright[Playwright]
+
+    Firestore -->|Reads Documents| Frontend
+
+    style Frontend fill:#4285f4,color:#fff
+    style Backend fill:#4285f4,color:#fff
+    style Professor fill:#9334e9,color:#fff
+    style Firestore fill:#ffa000,color:#fff
+    style CloudTasks fill:#34a853,color:#fff
+```
+
 ## Tech Stack
 
 - **Language**: Go

--- a/db/types.go
+++ b/db/types.go
@@ -3,12 +3,15 @@ package db
 import "time"
 
 const (
-	StatusPending   = "pending"
-	StatusCloning   = "cloning"
-	StatusBuilding  = "building"
-	StatusTesting   = "testing"
-	StatusCompleted = "completed"
-	StatusFailed    = "failed"
+	StatusQueued     = "queued"
+	StatusPending    = "pending"
+	StatusCloning    = "cloning"
+	StatusInstalling = "installing"
+	StatusBuilding   = "building"
+	StatusServing    = "serving"
+	StatusTesting    = "testing"
+	StatusCompleted  = "completed"
+	StatusFailed     = "failed"
 )
 
 type TestResult struct {

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,10 @@
+{
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": false
+    }
+  }
+}

--- a/firebase/firestore.go
+++ b/firebase/firestore.go
@@ -12,9 +12,18 @@ func GetFirestoreClient(app *firebase.App) (*firestore.Client, error) {
 	client, err := app.Firestore(context.Background())
 
 	if err != nil {
-		log.Println("Faild to get firestore client instance:", err)
+		log.Println("ERROR: Failed to get firestore client instance:", err)
 		return nil, err
 	}
 
 	return client, nil
+}
+
+func UpdateDoc(client *firestore.Client, collection, docId string, data map[string]any) {
+	ctx := context.Background()
+	_, err := client.Collection(collection).Doc(docId).Set(ctx, data, firestore.MergeAll)
+	
+	if err != nil {
+		log.Printf("ERROR: Failed to update %s/%s: %v", collection, docId, err)
+	}
 }

--- a/firebase/firestore.go
+++ b/firebase/firestore.go
@@ -19,11 +19,14 @@ func GetFirestoreClient(app *firebase.App) (*firestore.Client, error) {
 	return client, nil
 }
 
-func UpdateDoc(client *firestore.Client, collection, docId string, data map[string]any) {
+func UpdateDoc(client *firestore.Client, collection, docId string, data map[string]any) error {
 	ctx := context.Background()
 	_, err := client.Collection(collection).Doc(docId).Set(ctx, data, firestore.MergeAll)
-	
+
 	if err != nil {
 		log.Printf("ERROR: Failed to update %s/%s: %v", collection, docId, err)
+		return err
 	}
+
+	return nil
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,10 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // emulator dev only
+    // TODO update this if we want to test perms
+    match /{document=**} {
+      allow read, write: if true;
+    }
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,10 +1,19 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // emulator dev only
-    // TODO update this if we want to test perms
+    // ⚠️ WARNING: EMULATOR ONLY!! 
+
+    match /gradingJobs/{jobId} {
+      allow read, update: if true;
+      allow create, delete: if false; 
+    }
+
+    match /gradingJobsInternal/{jobId} {
+      allow read, update: if true;   
+      allow create, delete: if false; 
+
     match /{document=**} {
-      allow read, write: if true;
+      allow read, write: if false; 
     }
   }
 }

--- a/reporter/firestore_reporter.go
+++ b/reporter/firestore_reporter.go
@@ -1,6 +1,7 @@
 package reporter
 
 import (
+	"errors"
 	"sync"
 
 	"cloud.google.com/go/firestore"
@@ -22,11 +23,15 @@ type FirestoreReporter struct {
 	tests    map[string][]db.TestResult
 }
 
-func NewFirestoreReporter(fsClient *firestore.Client) *FirestoreReporter {
+func NewFirestoreReporter(fsClient *firestore.Client) (*FirestoreReporter, error) {
+	if fsClient == nil {
+		return nil, errors.New("fsClient argument for reporter is nil")
+	}
+
 	return &FirestoreReporter{
 		fsClient: fsClient,
 		tests:    make(map[string][]db.TestResult),
-	}
+	}, nil
 }
 
 func (r *FirestoreReporter) updatePublicDoc(jobId string, data map[string]any) {

--- a/reporter/firestore_reporter.go
+++ b/reporter/firestore_reporter.go
@@ -1,0 +1,71 @@
+package reporter
+
+import (
+	"sync"
+
+	"cloud.google.com/go/firestore"
+	"github.com/Hack4Impact-UMD/professor/db"
+	"github.com/Hack4Impact-UMD/professor/firebase"
+	"github.com/Hack4Impact-UMD/professor/util"
+)
+
+const (
+	maxLogBytes        = 50 * 1024 // 50KB 
+	maxTestOutputBytes = 10 * 1024 // 10KB 
+
+	collectionPublic   = "gradingJobs"
+	collectionInternal = "gradingJobsInternal"
+)
+
+type FirestoreReporter struct {
+	fsClient *firestore.Client
+	tests    map[string][]db.TestResult
+}
+
+func NewFirestoreReporter(fsClient *firestore.Client) *FirestoreReporter {
+	return &FirestoreReporter{
+		fsClient: fsClient,
+		tests:    make(map[string][]db.TestResult),
+	}
+}
+
+func (r *FirestoreReporter) updatePublicDoc(jobId string, data map[string]any) {
+	firebase.UpdateDoc(r.fsClient, collectionPublic, jobId, data)
+}
+
+func (r *FirestoreReporter) updateInternalDoc(jobId string, data map[string]any) {
+	firebase.UpdateDoc(r.fsClient, collectionInternal, jobId, data)
+}
+
+func (r *FirestoreReporter) OnGradeStart(jobId string) {
+	r.updatePublicDoc(jobId, map[string]any{
+		"status":  db.StatusPending,
+		"updated": firestore.ServerTimestamp,
+	})
+}
+
+// TODO: implement all of these; here for now to satisfy compiler
+
+func (r *FirestoreReporter) OnCloneStart(jobId string, assessmentRepo string, testRepo string) {}
+
+func (r *FirestoreReporter) OnCloneEnd(jobId string, assessmentRepo string, testRepo string, err error) {}
+
+func (r *FirestoreReporter) OnInstallStart(jobId string) {}
+
+func (r *FirestoreReporter) OnInstallEnd(jobId string, out string, err error) {}
+
+func (r *FirestoreReporter) OnBuildStart(jobId string) {}
+
+func (r *FirestoreReporter) OnBuildEnd(jobId string, out string, err error) {}
+
+func (r *FirestoreReporter) OnServe(jobId string, err error) {}
+
+func (r *FirestoreReporter) OnTestingStart(jobId string, suites []string, err error) {}
+
+func (r *FirestoreReporter) OnTestStart(jobId string, suite string, testName string) {}
+
+func (r *FirestoreReporter) OnTestEnd(jobId string, suite, testName string, passed bool, stdout, stderr string, testErrors []string, durationMs int64, err error) {}
+
+func (r *FirestoreReporter) OnTestingEnd(jobId string, err error) {}
+
+var _ util.GradingJobReporter = (*FirestoreReporter)(nil)

--- a/reporter/firestore_reporter.go
+++ b/reporter/firestore_reporter.go
@@ -120,13 +120,82 @@ func (r *FirestoreReporter) OnInstallEnd(jobId string, out string, err error) {
 	})
 }
 
-func (r *FirestoreReporter) OnBuildStart(jobId string) {}
+func (r *FirestoreReporter) OnBuildStart(jobId string) {
+	_ = r.updatePublicDoc(jobId, map[string]any{
+		"status":  db.StatusBuilding,
+		"updated": firestore.ServerTimestamp,
+	})
+}
 
-func (r *FirestoreReporter) OnBuildEnd(jobId string, out string, err error) {}
+func (r *FirestoreReporter) OnBuildEnd(jobId string, out string, err error) {
+	if err != nil {
+		_ = r.updatePublicDoc(jobId, map[string]any{
+			"status":    db.StatusFailed,
+			"error":     err.Error(),
+			"completed": firestore.ServerTimestamp,
+			"updated":   firestore.ServerTimestamp,
+		})
 
-func (r *FirestoreReporter) OnServe(jobId string, err error) {}
+		_ = r.updateInternalDoc(jobId, map[string]any{
+			"error":    err.Error(),
+			"buildLog": truncateLog(out, maxLogBytes),
+		})
 
-func (r *FirestoreReporter) OnTestingStart(jobId string, suites []string, err error) {}
+		return
+	}
+
+	_ = r.updatePublicDoc(jobId, map[string]any{
+		"updated": firestore.ServerTimestamp,
+	})
+
+	_ = r.updateInternalDoc(jobId, map[string]any{
+		"buildLog": truncateLog(out, maxLogBytes),
+	})
+}
+
+func (r *FirestoreReporter) OnServe(jobId string, err error) {
+	if err != nil {
+		_ = r.updatePublicDoc(jobId, map[string]any{
+			"status":    db.StatusFailed,
+			"error":     err.Error(),
+			"completed": firestore.ServerTimestamp,
+			"updated":   firestore.ServerTimestamp,
+		})
+
+		_ = r.updateInternalDoc(jobId, map[string]any{
+			"error": err.Error(),
+		})
+
+		return
+	}
+
+	_ = r.updatePublicDoc(jobId, map[string]any{
+		"status":  db.StatusServing,
+		"updated": firestore.ServerTimestamp,
+	})
+}
+
+func (r *FirestoreReporter) OnTestingStart(jobId string, suites []string, err error) {
+	if err != nil {
+		_ = r.updatePublicDoc(jobId, map[string]any{
+			"status":    db.StatusFailed,
+			"error":     err.Error(),
+			"completed": firestore.ServerTimestamp,
+			"updated":   firestore.ServerTimestamp,
+		})
+
+		_ = r.updateInternalDoc(jobId, map[string]any{
+			"error": err.Error(),
+		})
+
+		return
+	}
+
+	_ = r.updatePublicDoc(jobId, map[string]any{
+		"status":  db.StatusTesting,
+		"updated": firestore.ServerTimestamp,
+	})
+}
 
 func (r *FirestoreReporter) OnTestStart(jobId string, suite string, testName string) {}
 

--- a/reporter/firestore_reporter.go
+++ b/reporter/firestore_reporter.go
@@ -34,16 +34,16 @@ func NewFirestoreReporter(fsClient *firestore.Client) (*FirestoreReporter, error
 	}, nil
 }
 
-func (r *FirestoreReporter) updatePublicDoc(jobId string, data map[string]any) {
-	firebase.UpdateDoc(r.fsClient, collectionPublic, jobId, data)
+func (r *FirestoreReporter) updatePublicDoc(jobId string, data map[string]any) error {
+	return firebase.UpdateDoc(r.fsClient, collectionPublic, jobId, data)
 }
 
-func (r *FirestoreReporter) updateInternalDoc(jobId string, data map[string]any) {
-	firebase.UpdateDoc(r.fsClient, collectionInternal, jobId, data)
+func (r *FirestoreReporter) updateInternalDoc(jobId string, data map[string]any) error {
+	return firebase.UpdateDoc(r.fsClient, collectionInternal, jobId, data)
 }
 
 func (r *FirestoreReporter) OnGradeStart(jobId string) {
-	r.updatePublicDoc(jobId, map[string]any{
+	_ = r.updatePublicDoc(jobId, map[string]any{
 		"status":  db.StatusPending,
 		"updated": firestore.ServerTimestamp,
 	})

--- a/reporter/firestore_reporter.go
+++ b/reporter/firestore_reporter.go
@@ -55,7 +55,7 @@ func (r *FirestoreReporter) OnGradeStart(jobId string) {
 	})
 }
 
-func (r *FirestoreReporter) OnCloneStart(jobId string, assessmentRepo string, testRepo string) {
+func (r *FirestoreReporter) OnCloneStart(jobId, assessmentRepo, testRepo string) {
 	_ = r.updatePublicDoc(jobId, map[string]any{
 		"status":  db.StatusCloning,
 		"updated": firestore.ServerTimestamp,
@@ -66,7 +66,7 @@ func (r *FirestoreReporter) OnCloneStart(jobId string, assessmentRepo string, te
 	})
 }
 
-func (r *FirestoreReporter) OnCloneEnd(jobId string, assessmentRepo string, testRepo string, err error) {
+func (r *FirestoreReporter) OnCloneEnd(jobId, assessmentRepo, testRepo string, err error) {
 	if err != nil {
 		_ = r.updatePublicDoc(jobId, map[string]any{
 			"status":    db.StatusFailed,
@@ -94,7 +94,7 @@ func (r *FirestoreReporter) OnInstallStart(jobId string) {
 	})
 }
 
-func (r *FirestoreReporter) OnInstallEnd(jobId string, out string, err error) {
+func (r *FirestoreReporter) OnInstallEnd(jobId, out string, err error) {
 	if err != nil {
 		_ = r.updatePublicDoc(jobId, map[string]any{
 			"status":    db.StatusFailed,
@@ -127,7 +127,7 @@ func (r *FirestoreReporter) OnBuildStart(jobId string) {
 	})
 }
 
-func (r *FirestoreReporter) OnBuildEnd(jobId string, out string, err error) {
+func (r *FirestoreReporter) OnBuildEnd(jobId, out string, err error) {
 	if err != nil {
 		_ = r.updatePublicDoc(jobId, map[string]any{
 			"status":    db.StatusFailed,
@@ -197,10 +197,70 @@ func (r *FirestoreReporter) OnTestingStart(jobId string, suites []string, err er
 	})
 }
 
-func (r *FirestoreReporter) OnTestStart(jobId string, suite string, testName string) {}
+func (r *FirestoreReporter) OnTestStart(jobId, suite, testName string) {
+	// No-op rn as it would incur a lot of extra writes, but could update timestamp later
+}
 
-func (r *FirestoreReporter) OnTestEnd(jobId string, suite, testName string, passed bool, stdout, stderr string, testErrors []string, durationMs int64, err error) {}
+func (r *FirestoreReporter) OnTestEnd(jobId, suite, testName string, passed bool, stdout, stderr string, testErrors []string, durationMs int64, err error) {
+	result := db.TestResult{
+		Suite:      suite,
+		TestName:   testName,
+		Passed:     passed,
+		Stdout:     truncateLog(stdout, maxTestOutputBytes),
+		Stderr:     truncateLog(stderr, maxTestOutputBytes),
+		Errors:     testErrors,
+		DurationMs: durationMs,
+		Points:     0, // TODO: implement point extraction to fill this
+	}
 
-func (r *FirestoreReporter) OnTestingEnd(jobId string, err error) {}
+	_ = r.updateInternalDoc(jobId, map[string]any{
+		"tests": map[string]any{
+			suite: firestore.ArrayUnion(result),
+		},
+	})
+
+	publicTestUpdates := map[string]any{
+		"suiteName": suite,
+		"total":     firestore.Increment(1),
+		"durationMs": firestore.Increment(durationMs),
+	}
+
+	if passed {
+		publicTestUpdates["passed"] = firestore.Increment(1)
+	} else {
+		publicTestUpdates["failed"] = firestore.Increment(1)
+	}
+
+	publicTestUpdates["points"] = firestore.Increment(result.Points)
+	publicTestUpdates["totalPoints"] = firestore.Increment(result.Points)
+
+	_ = r.updatePublicDoc(jobId, map[string]any{
+		"completedTests": firestore.Increment(1),
+		"updated":        firestore.ServerTimestamp,
+		"publicTests": map[string]any{
+			suite: publicTestUpdates,
+		},
+	})
+}
+
+func (r *FirestoreReporter) OnTestingEnd(jobId string, err error) {
+	data := map[string]any{
+		"updated":   firestore.ServerTimestamp,
+		"completed": firestore.ServerTimestamp,
+	}
+
+	if err != nil {
+		data["status"] = db.StatusFailed
+		data["error"] = err.Error()
+
+		_ = r.updateInternalDoc(jobId, map[string]any{
+			"error": err.Error(),
+		})
+	} else {
+		data["status"] = db.StatusCompleted
+	}
+
+	_ = r.updatePublicDoc(jobId, data)
+}
 
 var _ util.GradingJobReporter = (*FirestoreReporter)(nil)

--- a/reporter/firestore_reporter.go
+++ b/reporter/firestore_reporter.go
@@ -244,23 +244,26 @@ func (r *FirestoreReporter) OnTestEnd(jobId, suite, testName string, passed bool
 }
 
 func (r *FirestoreReporter) OnTestingEnd(jobId string, err error) {
-	data := map[string]any{
-		"updated":   firestore.ServerTimestamp,
-		"completed": firestore.ServerTimestamp,
-	}
-
 	if err != nil {
-		data["status"] = db.StatusFailed
-		data["error"] = err.Error()
+		_ = r.updatePublicDoc(jobId, map[string]any{
+			"status":    db.StatusFailed,
+			"error":     err.Error(),
+			"completed": firestore.ServerTimestamp,
+			"updated":   firestore.ServerTimestamp,
+		})
 
 		_ = r.updateInternalDoc(jobId, map[string]any{
 			"error": err.Error(),
 		})
-	} else {
-		data["status"] = db.StatusCompleted
+
+		return
 	}
 
-	_ = r.updatePublicDoc(jobId, data)
+	_ = r.updatePublicDoc(jobId, map[string]any{
+		"status":  db.StatusCompleted,
+		"completed": firestore.ServerTimestamp,
+		"updated": firestore.ServerTimestamp,
+	})
 }
 
 var _ util.GradingJobReporter = (*FirestoreReporter)(nil)

--- a/reporter/firestore_reporter.go
+++ b/reporter/firestore_reporter.go
@@ -2,7 +2,6 @@ package reporter
 
 import (
 	"errors"
-	"sync"
 
 	"cloud.google.com/go/firestore"
 	"github.com/Hack4Impact-UMD/professor/db"
@@ -42,6 +41,13 @@ func (r *FirestoreReporter) updateInternalDoc(jobId string, data map[string]any)
 	return firebase.UpdateDoc(r.fsClient, collectionInternal, jobId, data)
 }
 
+func truncateLog(log string, maxBytes int) string {
+	if len(log) <= maxBytes {
+		return log
+	}
+	return "Tail:\n" + log[len(log)-maxBytes:]
+}
+
 func (r *FirestoreReporter) OnGradeStart(jobId string) {
 	_ = r.updatePublicDoc(jobId, map[string]any{
 		"status":  db.StatusPending,
@@ -49,15 +55,58 @@ func (r *FirestoreReporter) OnGradeStart(jobId string) {
 	})
 }
 
-// TODO: implement all of these; here for now to satisfy compiler
+func (r *FirestoreReporter) OnCloneStart(jobId string, assessmentRepo string, testRepo string) {
+	_ = r.updatePublicDoc(jobId, map[string]any{
+		"status":  db.StatusCloning,
+		"updated": firestore.ServerTimestamp,
+	})
 
-func (r *FirestoreReporter) OnCloneStart(jobId string, assessmentRepo string, testRepo string) {}
+	_ = r.updateInternalDoc(jobId, map[string]any{
+		"testRepo": testRepo,
+	})
+}
 
-func (r *FirestoreReporter) OnCloneEnd(jobId string, assessmentRepo string, testRepo string, err error) {}
+func (r *FirestoreReporter) OnCloneEnd(jobId string, assessmentRepo string, testRepo string, err error) {
+	if err != nil {
+		_ = r.updatePublicDoc(jobId, map[string]any{
+			"status":    db.StatusFailed,
+			"error":     err.Error(),
+			"completed": firestore.ServerTimestamp,
+			"updated":   firestore.ServerTimestamp,
+		})
 
-func (r *FirestoreReporter) OnInstallStart(jobId string) {}
+		_ = r.updateInternalDoc(jobId, map[string]any{
+			"error": err.Error(),
+		})
+	}
+}
 
-func (r *FirestoreReporter) OnInstallEnd(jobId string, out string, err error) {}
+func (r *FirestoreReporter) OnInstallStart(jobId string) {
+	_ = r.updatePublicDoc(jobId, map[string]any{
+		"status":  db.StatusInstalling,
+		"updated": firestore.ServerTimestamp,
+	})
+}
+
+func (r *FirestoreReporter) OnInstallEnd(jobId string, out string, err error) {
+	if err != nil {
+		_ = r.updatePublicDoc(jobId, map[string]any{
+			"status":    db.StatusFailed,
+			"error":     err.Error(),
+			"completed": firestore.ServerTimestamp,
+			"updated":   firestore.ServerTimestamp,
+		})
+
+		_ = r.updateInternalDoc(jobId, map[string]any{
+			"error":      err.Error(),
+			"installLog": truncateLog(out, maxLogBytes),
+		})
+	} else {
+		_ = r.updateInternalDoc(jobId, map[string]any{
+			"installLog": truncateLog(out, maxLogBytes),
+		})
+	}
+}
 
 func (r *FirestoreReporter) OnBuildStart(jobId string) {}
 

--- a/reporter/firestore_reporter.go
+++ b/reporter/firestore_reporter.go
@@ -78,7 +78,13 @@ func (r *FirestoreReporter) OnCloneEnd(jobId string, assessmentRepo string, test
 		_ = r.updateInternalDoc(jobId, map[string]any{
 			"error": err.Error(),
 		})
+
+		return
 	}
+	
+	_ = r.updatePublicDoc(jobId, map[string]any{
+		"updated": firestore.ServerTimestamp,
+	})
 }
 
 func (r *FirestoreReporter) OnInstallStart(jobId string) {
@@ -101,11 +107,17 @@ func (r *FirestoreReporter) OnInstallEnd(jobId string, out string, err error) {
 			"error":      err.Error(),
 			"installLog": truncateLog(out, maxLogBytes),
 		})
-	} else {
-		_ = r.updateInternalDoc(jobId, map[string]any{
-			"installLog": truncateLog(out, maxLogBytes),
-		})
+
+		return
 	}
+	
+	_ = r.updatePublicDoc(jobId, map[string]any{
+		"updated": firestore.ServerTimestamp,
+	})
+
+	_ = r.updateInternalDoc(jobId, map[string]any{
+		"installLog": truncateLog(out, maxLogBytes),
+	})
 }
 
 func (r *FirestoreReporter) OnBuildStart(jobId string) {}

--- a/reporter/firestore_reporter_test.go
+++ b/reporter/firestore_reporter_test.go
@@ -1,0 +1,90 @@
+package reporter
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/Hack4Impact-UMD/professor/db"
+	"github.com/Hack4Impact-UMD/professor/firebase"
+)
+
+func TestFirestoreReporter(t *testing.T) {
+
+	// === Init Firebase stuff ===
+
+	ctx := context.Background()
+
+	app, err := firebase.GetFirebaseApp(true)
+	if err != nil {
+		t.Fatalf("Failed to create Firebase app: %v", err)
+	}
+
+	client, err := firebase.GetFirestoreClient(app)
+	if err != nil {
+		t.Fatalf("Failed to create Firestore client: %v", err)
+	}
+	defer client.Close()
+
+	reporter := NewFirestoreReporter(client)
+	jobId := "firestore_reporter_test"
+	initialData := map[string]any{
+		"id":         jobId,
+		"status":     db.StatusQueued,
+		"repoURL":    "https://github.com/test/repo",
+		"responseId": "abc123",
+	}
+
+	// === Mock job creation by Express backend ===
+
+	_, err = client.Collection(collectionPublic).Doc(jobId).Set(ctx, initialData)
+	if err != nil {
+		t.Fatalf("Failed to create initial test document: %v", err)
+	}
+
+	// === TESTS ===
+
+	t.Run("OnGradeStart updates status", func(t *testing.T) {
+		reporter.OnGradeStart(jobId)
+
+		doc, err := client.Collection(collectionPublic).Doc(jobId).Get(ctx)
+		if err != nil {
+			t.Fatalf("Failed to read document: %v", err)
+		}
+		data := doc.Data()
+
+		status, ok := data["status"].(string)
+		if !ok {
+			t.Fatalf("status field missing or wrong type")
+		}
+		if status != db.StatusPending {
+			t.Errorf("Expected status %q, got %q", db.StatusPending, status)
+		}
+		
+		if _, ok := data["updated"]; !ok {
+			t.Error("updated timestamp not set")
+		}
+	})
+
+	// === Validate unchanged fields after all tests ===
+
+	finalDoc, err := client.Collection(collectionPublic).Doc(jobId).Get(ctx)
+	if err != nil {
+		t.Fatalf("Failed to read document for invariants: %v", err)
+	}
+	finalData := finalDoc.Data()
+
+	if initialData["id"] != finalData["id"] {
+		t.Error("id field was lost")
+	}
+	if initialData["repoURL"] != finalData["repoURL"] {
+		t.Error("repoURL field was lost")
+	}
+	if initialData["responseId"] != finalData["responseId"] {
+		t.Error("responseId field was lost")
+	}
+
+	// === Cleanup ===
+
+	client.Collection(collectionPublic).Doc(jobId).Delete(ctx)
+}

--- a/reporter/firestore_reporter_test.go
+++ b/reporter/firestore_reporter_test.go
@@ -85,30 +85,6 @@ func assertFieldExists(t *testing.T, ctx context.Context, client *firestore.Clie
 	}
 }
 
-func assertUpdateTimeChanged(t *testing.T, ctx context.Context, client *firestore.Client, jobId, collection string, before time.Time) {
-	t.Helper()
-	doc, err := client.Collection(collection).Doc(jobId).Get(ctx)
-	if err != nil {
-		t.Fatalf("Failed to read document: %v", err)
-	}
-
-	updatedField, ok := doc.Data()["updated"]
-	if !ok {
-		t.Error("Field 'updated' does not exist")
-		return
-	}
-
-	updatedTime, ok := updatedField.(time.Time)
-	if !ok {
-		t.Errorf("Field 'updated' is not a time.Time, got %T", updatedField)
-		return
-	}
-
-	if !updatedTime.After(before) {
-		t.Errorf("'updated' field should have changed: before=%v, after=%v", before, updatedTime)
-	}
-}
-
 func TestFirestoreReporter(t *testing.T) {
 	ctx, client, reporter := setupTest(t)
 
@@ -118,35 +94,25 @@ func TestFirestoreReporter(t *testing.T) {
 	defer cleanupJobDocs(ctx, client, jobId)
 
 	t.Run("OnGradeStart updates status", func(t *testing.T) {
-		before := time.Now()
-
 		reporter.OnGradeStart(jobId)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusPending)
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnCloneStart updates status and stores testRepo", func(t *testing.T) {
-		before := time.Now()
-
 		reporter.OnCloneStart(jobId, "user/assessment", "h4i/tests")
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusCloning)
 		assertField(t, ctx, client, jobId, collectionInternal, "testRepo", "h4i/tests")
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnCloneEnd with no error only updates timestamp", func(t *testing.T) {
-		before := time.Now()
-
 		reporter.OnCloneEnd(jobId, "user/assessment", "h4i/tests", nil)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusCloning)
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnCloneEnd with error marks job as failed", func(t *testing.T) {
-		before := time.Now()
 		testErr := errors.New("git clone failed: repository not found")
 
 		reporter.OnCloneEnd(jobId, "user/assessment", "h4i/tests", testErr)
@@ -155,30 +121,23 @@ func TestFirestoreReporter(t *testing.T) {
 		assertField(t, ctx, client, jobId, collectionPublic, "error", testErr.Error())
 		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
 		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnInstallStart updates status", func(t *testing.T) {
-		before := time.Now()
-
 		reporter.OnInstallStart(jobId)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusInstalling)
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnInstallEnd with success stores log", func(t *testing.T) {
-		before := time.Now()
 		installOutput := "npm install successful\ninstalled 42 packages"
 
 		reporter.OnInstallEnd(jobId, installOutput, nil)
 
 		assertField(t, ctx, client, jobId, collectionInternal, "installLog", installOutput)
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnInstallEnd with error marks job as failed", func(t *testing.T) {
-		before := time.Now()
 		testErr := errors.New("npm install failed: ENOENT package.json")
 		installOutput := "Error: cannot find package.json"
 
@@ -189,30 +148,23 @@ func TestFirestoreReporter(t *testing.T) {
 		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
 		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
 		assertField(t, ctx, client, jobId, collectionInternal, "installLog", installOutput)
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnBuildStart updates status", func(t *testing.T) {
-		before := time.Now()
-
 		reporter.OnBuildStart(jobId)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusBuilding)
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnBuildEnd with success stores log", func(t *testing.T) {
-		before := time.Now()
 		buildOutput := "Build successful\nCompiled 15 files"
 
 		reporter.OnBuildEnd(jobId, buildOutput, nil)
 
 		assertField(t, ctx, client, jobId, collectionInternal, "buildLog", buildOutput)
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnBuildEnd with error marks job as failed", func(t *testing.T) {
-		before := time.Now()
 		testErr := errors.New("build failed: syntax error")
 		buildOutput := "Error: unexpected token"
 
@@ -223,20 +175,15 @@ func TestFirestoreReporter(t *testing.T) {
 		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
 		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
 		assertField(t, ctx, client, jobId, collectionInternal, "buildLog", buildOutput)
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnServe with no error updates status to serving", func(t *testing.T) {
-		before := time.Now()
-
 		reporter.OnServe(jobId, nil)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusServing)
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnServe with error marks job as failed", func(t *testing.T) {
-		before := time.Now()
 		testErr := errors.New("failed to start server: port already in use")
 
 		reporter.OnServe(jobId, testErr)
@@ -245,20 +192,15 @@ func TestFirestoreReporter(t *testing.T) {
 		assertField(t, ctx, client, jobId, collectionPublic, "error", testErr.Error())
 		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
 		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnTestingStart with no error updates status to testing", func(t *testing.T) {
-		before := time.Now()
-
 		reporter.OnTestingStart(jobId, []string{"suite1", "suite2"}, nil)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusTesting)
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnTestingStart with error marks job as failed", func(t *testing.T) {
-		before := time.Now()
 		testErr := errors.New("failed to discover tests")
 
 		reporter.OnTestingStart(jobId, nil, testErr)
@@ -267,7 +209,6 @@ func TestFirestoreReporter(t *testing.T) {
 		assertField(t, ctx, client, jobId, collectionPublic, "error", testErr.Error())
 		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
 		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnTestStart doesn't panic", func(t *testing.T) {
@@ -275,8 +216,6 @@ func TestFirestoreReporter(t *testing.T) {
 	})
 
 	t.Run("OnTestEnd with passing test writes result and updates aggregations", func(t *testing.T) {
-		before := time.Now()
-
 		reporter.OnTestEnd(jobId, "suite1", "test1", true, "stdout output", "stderr output", []string{}, 150, nil)
 
 		doc, err := client.Collection(collectionInternal).Doc(jobId).Get(ctx)
@@ -296,7 +235,6 @@ func TestFirestoreReporter(t *testing.T) {
 		}
 
 		assertField(t, ctx, client, jobId, collectionPublic, "completedTests", int64(1))
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 
 		publicDoc, err := client.Collection(collectionPublic).Doc(jobId).Get(ctx)
 		if err != nil {
@@ -312,8 +250,6 @@ func TestFirestoreReporter(t *testing.T) {
 	})
 
 	t.Run("OnTestEnd with failing test updates aggregations correctly", func(t *testing.T) {
-		before := time.Now()
-
 		reporter.OnTestEnd(jobId, "suite1", "test2", false, "stdout", "stderr", []string{"error1"}, 200, nil)
 
 		doc, err := client.Collection(collectionInternal).Doc(jobId).Get(ctx)
@@ -333,7 +269,6 @@ func TestFirestoreReporter(t *testing.T) {
 		}
 
 		assertField(t, ctx, client, jobId, collectionPublic, "completedTests", int64(2))
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 
 		publicDoc, err := client.Collection(collectionPublic).Doc(jobId).Get(ctx)
 		if err != nil {
@@ -349,17 +284,13 @@ func TestFirestoreReporter(t *testing.T) {
 	})
 
 	t.Run("OnTestingEnd with no error marks job as completed", func(t *testing.T) {
-		before := time.Now()
-
 		reporter.OnTestingEnd(jobId, nil)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusCompleted)
 		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnTestingEnd with error marks job as failed", func(t *testing.T) {
-		before := time.Now()
 		testErr := errors.New("playwright tests crashed")
 
 		reporter.OnTestingEnd(jobId, testErr)
@@ -368,6 +299,5 @@ func TestFirestoreReporter(t *testing.T) {
 		assertField(t, ctx, client, jobId, collectionPublic, "error", testErr.Error())
 		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
 		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
-		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 }

--- a/reporter/firestore_reporter_test.go
+++ b/reporter/firestore_reporter_test.go
@@ -191,4 +191,82 @@ func TestFirestoreReporter(t *testing.T) {
 		assertField(t, ctx, client, jobId, collectionInternal, "installLog", installOutput)
 		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
+
+	t.Run("OnBuildStart updates status", func(t *testing.T) {
+		before := time.Now()
+
+		reporter.OnBuildStart(jobId)
+
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusBuilding)
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
+	})
+
+	t.Run("OnBuildEnd with success stores log", func(t *testing.T) {
+		before := time.Now()
+		buildOutput := "Build successful\nCompiled 15 files"
+
+		reporter.OnBuildEnd(jobId, buildOutput, nil)
+
+		assertField(t, ctx, client, jobId, collectionInternal, "buildLog", buildOutput)
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
+	})
+
+	t.Run("OnBuildEnd with error marks job as failed", func(t *testing.T) {
+		before := time.Now()
+		testErr := errors.New("build failed: syntax error")
+		buildOutput := "Error: unexpected token"
+
+		reporter.OnBuildEnd(jobId, buildOutput, testErr)
+
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusFailed)
+		assertField(t, ctx, client, jobId, collectionPublic, "error", testErr.Error())
+		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
+		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
+		assertField(t, ctx, client, jobId, collectionInternal, "buildLog", buildOutput)
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
+	})
+
+	t.Run("OnServe with no error updates status to serving", func(t *testing.T) {
+		before := time.Now()
+
+		reporter.OnServe(jobId, nil)
+
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusServing)
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
+	})
+
+	t.Run("OnServe with error marks job as failed", func(t *testing.T) {
+		before := time.Now()
+		testErr := errors.New("failed to start server: port already in use")
+
+		reporter.OnServe(jobId, testErr)
+
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusFailed)
+		assertField(t, ctx, client, jobId, collectionPublic, "error", testErr.Error())
+		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
+		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
+	})
+
+	t.Run("OnTestingStart with no error updates status to testing", func(t *testing.T) {
+		before := time.Now()
+
+		reporter.OnTestingStart(jobId, []string{"suite1", "suite2"}, nil)
+
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusTesting)
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
+	})
+
+	t.Run("OnTestingStart with error marks job as failed", func(t *testing.T) {
+		before := time.Now()
+		testErr := errors.New("failed to discover tests")
+
+		reporter.OnTestingStart(jobId, nil, testErr)
+
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusFailed)
+		assertField(t, ctx, client, jobId, collectionPublic, "error", testErr.Error())
+		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
+		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
+	})
 }

--- a/reporter/firestore_reporter_test.go
+++ b/reporter/firestore_reporter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	"github.com/Hack4Impact-UMD/professor/db"
@@ -84,6 +85,30 @@ func assertFieldExists(t *testing.T, ctx context.Context, client *firestore.Clie
 	}
 }
 
+func assertUpdateTimeChanged(t *testing.T, ctx context.Context, client *firestore.Client, jobId, collection string, before time.Time) {
+	t.Helper()
+	doc, err := client.Collection(collection).Doc(jobId).Get(ctx)
+	if err != nil {
+		t.Fatalf("Failed to read document: %v", err)
+	}
+
+	updatedField, ok := doc.Data()["updated"]
+	if !ok {
+		t.Error("Field 'updated' does not exist")
+		return
+	}
+
+	updatedTime, ok := updatedField.(time.Time)
+	if !ok {
+		t.Errorf("Field 'updated' is not a time.Time, got %T", updatedField)
+		return
+	}
+
+	if !updatedTime.After(before) {
+		t.Errorf("'updated' field should have changed: before=%v, after=%v", before, updatedTime)
+	}
+}
+
 func TestFirestoreReporter(t *testing.T) {
 	ctx, client, reporter := setupTest(t)
 
@@ -93,52 +118,70 @@ func TestFirestoreReporter(t *testing.T) {
 	defer cleanupJobDocs(ctx, client, jobId)
 
 	t.Run("OnGradeStart updates status", func(t *testing.T) {
+		before := time.Now()
+
 		reporter.OnGradeStart(jobId)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusPending)
-		assertFieldExists(t, ctx, client, jobId, collectionPublic, "updated")
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnCloneStart updates status and stores testRepo", func(t *testing.T) {
+		before := time.Now()
+
 		reporter.OnCloneStart(jobId, "user/assessment", "h4i/tests")
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusCloning)
 		assertField(t, ctx, client, jobId, collectionInternal, "testRepo", "h4i/tests")
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
-	t.Run("OnCloneEnd with no error does nothing", func(t *testing.T) {
+	t.Run("OnCloneEnd with no error only updates timestamp", func(t *testing.T) {
+		before := time.Now()
+
 		reporter.OnCloneEnd(jobId, "user/assessment", "h4i/tests", nil)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusCloning)
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnCloneEnd with error marks job as failed", func(t *testing.T) {
+		before := time.Now()
 		testErr := errors.New("git clone failed: repository not found")
+
 		reporter.OnCloneEnd(jobId, "user/assessment", "h4i/tests", testErr)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusFailed)
 		assertField(t, ctx, client, jobId, collectionPublic, "error", testErr.Error())
 		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
 		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnInstallStart updates status", func(t *testing.T) {
+		before := time.Now()
+
 		reporter.OnInstallStart(jobId)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusInstalling)
-		assertFieldExists(t, ctx, client, jobId, collectionPublic, "updated")
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnInstallEnd with success stores log", func(t *testing.T) {
+		before := time.Now()
 		installOutput := "npm install successful\ninstalled 42 packages"
+
 		reporter.OnInstallEnd(jobId, installOutput, nil)
 
 		assertField(t, ctx, client, jobId, collectionInternal, "installLog", installOutput)
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 
 	t.Run("OnInstallEnd with error marks job as failed", func(t *testing.T) {
+		before := time.Now()
 		testErr := errors.New("npm install failed: ENOENT package.json")
 		installOutput := "Error: cannot find package.json"
+
 		reporter.OnInstallEnd(jobId, installOutput, testErr)
 
 		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusFailed)
@@ -146,5 +189,6 @@ func TestFirestoreReporter(t *testing.T) {
 		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
 		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
 		assertField(t, ctx, client, jobId, collectionInternal, "installLog", installOutput)
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
 }

--- a/reporter/firestore_reporter_test.go
+++ b/reporter/firestore_reporter_test.go
@@ -269,4 +269,105 @@ func TestFirestoreReporter(t *testing.T) {
 		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
 		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
 	})
+
+	t.Run("OnTestStart doesn't panic", func(t *testing.T) {
+		reporter.OnTestStart(jobId, "suite1", "test1")
+	})
+
+	t.Run("OnTestEnd with passing test writes result and updates aggregations", func(t *testing.T) {
+		before := time.Now()
+
+		reporter.OnTestEnd(jobId, "suite1", "test1", true, "stdout output", "stderr output", []string{}, 150, nil)
+
+		doc, err := client.Collection(collectionInternal).Doc(jobId).Get(ctx)
+		if err != nil {
+			t.Fatalf("Failed to read internal document: %v", err)
+		}
+
+		tests := doc.Data()["tests"].(map[string]any)
+		suite1Tests := tests["suite1"].([]any)
+		if len(suite1Tests) != 1 {
+			t.Fatalf("Expected 1 test in suite1, got %d", len(suite1Tests))
+		}
+
+		testResult := suite1Tests[0].(map[string]any)
+		if testResult["testName"] != "test1" || testResult["passed"] != true {
+			t.Errorf("Test result incorrect: %v", testResult)
+		}
+
+		assertField(t, ctx, client, jobId, collectionPublic, "completedTests", int64(1))
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
+
+		publicDoc, err := client.Collection(collectionPublic).Doc(jobId).Get(ctx)
+		if err != nil {
+			t.Fatalf("Failed to read public document: %v", err)
+		}
+
+		publicTests := publicDoc.Data()["publicTests"].(map[string]any)
+		suite1 := publicTests["suite1"].(map[string]any)
+
+		if suite1["passed"] != int64(1) || suite1["total"] != int64(1) || suite1["durationMs"] != int64(150) {
+			t.Errorf("Suite aggregations incorrect: %v", suite1)
+		}
+	})
+
+	t.Run("OnTestEnd with failing test updates aggregations correctly", func(t *testing.T) {
+		before := time.Now()
+
+		reporter.OnTestEnd(jobId, "suite1", "test2", false, "stdout", "stderr", []string{"error1"}, 200, nil)
+
+		doc, err := client.Collection(collectionInternal).Doc(jobId).Get(ctx)
+		if err != nil {
+			t.Fatalf("Failed to read internal document: %v", err)
+		}
+
+		tests := doc.Data()["tests"].(map[string]any)
+		suite1Tests := tests["suite1"].([]any)
+		if len(suite1Tests) != 2 {
+			t.Fatalf("Expected 2 tests in suite1, got %d", len(suite1Tests))
+		}
+
+		testResult := suite1Tests[1].(map[string]any)
+		if testResult["testName"] != "test2" || testResult["passed"] != false {
+			t.Errorf("Test result incorrect: %v", testResult)
+		}
+
+		assertField(t, ctx, client, jobId, collectionPublic, "completedTests", int64(2))
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
+
+		publicDoc, err := client.Collection(collectionPublic).Doc(jobId).Get(ctx)
+		if err != nil {
+			t.Fatalf("Failed to read public document: %v", err)
+		}
+
+		publicTests := publicDoc.Data()["publicTests"].(map[string]any)
+		suite1 := publicTests["suite1"].(map[string]any)
+
+		if suite1["passed"] != int64(1) || suite1["failed"] != int64(1) || suite1["total"] != int64(2) || suite1["durationMs"] != int64(350) {
+			t.Errorf("Suite aggregations incorrect: %v", suite1)
+		}
+	})
+
+	t.Run("OnTestingEnd with no error marks job as completed", func(t *testing.T) {
+		before := time.Now()
+
+		reporter.OnTestingEnd(jobId, nil)
+
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusCompleted)
+		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
+	})
+
+	t.Run("OnTestingEnd with error marks job as failed", func(t *testing.T) {
+		before := time.Now()
+		testErr := errors.New("playwright tests crashed")
+
+		reporter.OnTestingEnd(jobId, testErr)
+
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusFailed)
+		assertField(t, ctx, client, jobId, collectionPublic, "error", testErr.Error())
+		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
+		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
+		assertUpdateTimeChanged(t, ctx, client, jobId, collectionPublic, before)
+	})
 }

--- a/reporter/firestore_reporter_test.go
+++ b/reporter/firestore_reporter_test.go
@@ -2,16 +2,15 @@ package reporter
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"cloud.google.com/go/firestore"
 	"github.com/Hack4Impact-UMD/professor/db"
 	"github.com/Hack4Impact-UMD/professor/firebase"
 )
 
-func TestFirestoreReporter(t *testing.T) {
-
-	// === Init Firebase stuff ===
-
+func setupTest(t *testing.T) (context.Context, *firestore.Client, *FirestoreReporter) {
 	ctx := context.Background()
 
 	app, err := firebase.GetFirebaseApp(true)
@@ -23,71 +22,129 @@ func TestFirestoreReporter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Firestore client: %v", err)
 	}
-	defer client.Close()
+	t.Cleanup(func() { client.Close() })
 
 	reporter, err := NewFirestoreReporter(client)
 	if err != nil {
 		t.Fatalf("Failed to create reporter: %v", err)
 	}
 
-	jobId := "firestore_reporter_test"
-	initialData := map[string]any{
-		"id":         jobId,
-		"status":     db.StatusQueued,
-		"repoURL":    "https://github.com/test/repo",
-		"responseId": "abc123",
-	}
+	return ctx, client, reporter
+}
 
-	// === Mock job creation by Express backend ===
-
-	_, err = client.Collection(collectionPublic).Doc(jobId).Set(ctx, initialData)
+func setupJobDocs(t *testing.T, ctx context.Context, client *firestore.Client, jobId string) {
+	_, err := client.Collection(collectionPublic).Doc(jobId).Set(ctx, map[string]any{
+		"id":     jobId,
+		"status": db.StatusPending,
+	})
 	if err != nil {
-		t.Fatalf("Failed to create initial test document: %v", err)
+		t.Fatalf("Failed to create test gradingJobs document: %v", err)
 	}
 
-	// === TESTS ===
+	_, err = client.Collection(collectionInternal).Doc(jobId).Set(ctx, map[string]any{
+		"id": jobId,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create test gradingJobsInternal document: %v", err)
+	}
+}
+
+func cleanupJobDocs(ctx context.Context, client *firestore.Client, jobId string) {
+	client.Collection(collectionPublic).Doc(jobId).Delete(ctx)
+	client.Collection(collectionInternal).Doc(jobId).Delete(ctx)
+}
+
+func assertField(t *testing.T, ctx context.Context, client *firestore.Client, jobId, collection, field string, expected any) {
+	t.Helper()
+	doc, err := client.Collection(collection).Doc(jobId).Get(ctx)
+	if err != nil {
+		t.Fatalf("Failed to read document: %v", err)
+	}
+
+	actual, ok := doc.Data()[field]
+	if !ok {
+		t.Errorf("Field %q does not exist", field)
+		return
+	}
+
+	if actual != expected {
+		t.Errorf("Field %q: expected %q, got %q", field, expected, actual)
+	}
+}
+
+func assertFieldExists(t *testing.T, ctx context.Context, client *firestore.Client, jobId, collection, field string) {
+	t.Helper()
+	doc, err := client.Collection(collection).Doc(jobId).Get(ctx)
+	if err != nil {
+		t.Fatalf("Failed to read document: %v", err)
+	}
+
+	if _, exists := doc.Data()[field]; !exists {
+		t.Errorf("Field %q should exist but doesn't", field)
+	}
+}
+
+func TestFirestoreReporter(t *testing.T) {
+	ctx, client, reporter := setupTest(t)
+
+	jobId := "firestore_reporter_test"
+	setupJobDocs(t, ctx, client, jobId)
+	
+	defer cleanupJobDocs(ctx, client, jobId)
 
 	t.Run("OnGradeStart updates status", func(t *testing.T) {
 		reporter.OnGradeStart(jobId)
 
-		doc, err := client.Collection(collectionPublic).Doc(jobId).Get(ctx)
-		if err != nil {
-			t.Fatalf("Failed to read document: %v", err)
-		}
-		data := doc.Data()
-
-		status, ok := data["status"].(string)
-		if !ok {
-			t.Fatalf("status field missing or wrong type")
-		}
-		if status != db.StatusPending {
-			t.Errorf("Expected status %q, got %q", db.StatusPending, status)
-		}
-		
-		if _, ok := data["updated"]; !ok {
-			t.Error("updated timestamp not set")
-		}
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusPending)
+		assertFieldExists(t, ctx, client, jobId, collectionPublic, "updated")
 	})
 
-	// === Validate unchanged fields after all tests ===
+	t.Run("OnCloneStart updates status and stores testRepo", func(t *testing.T) {
+		reporter.OnCloneStart(jobId, "user/assessment", "h4i/tests")
 
-	finalDoc, err := client.Collection(collectionPublic).Doc(jobId).Get(ctx)
-	if err != nil {
-		t.Fatalf("Failed to read document for invariants: %v", err)
-	}
-	finalData := finalDoc.Data()
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusCloning)
+		assertField(t, ctx, client, jobId, collectionInternal, "testRepo", "h4i/tests")
+	})
 
-	if initialData["id"] != finalData["id"] {
-		t.Error("id field was lost")
-	}
-	if initialData["repoURL"] != finalData["repoURL"] {
-		t.Error("repoURL field was lost")
-	}
-	if initialData["responseId"] != finalData["responseId"] {
-		t.Error("responseId field was lost")
-	}
+	t.Run("OnCloneEnd with no error does nothing", func(t *testing.T) {
+		reporter.OnCloneEnd(jobId, "user/assessment", "h4i/tests", nil)
 
-	// === Cleanup ===
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusCloning)
+	})
 
-	client.Collection(collectionPublic).Doc(jobId).Delete(ctx)
+	t.Run("OnCloneEnd with error marks job as failed", func(t *testing.T) {
+		testErr := errors.New("git clone failed: repository not found")
+		reporter.OnCloneEnd(jobId, "user/assessment", "h4i/tests", testErr)
+
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusFailed)
+		assertField(t, ctx, client, jobId, collectionPublic, "error", testErr.Error())
+		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
+		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
+	})
+
+	t.Run("OnInstallStart updates status", func(t *testing.T) {
+		reporter.OnInstallStart(jobId)
+
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusInstalling)
+		assertFieldExists(t, ctx, client, jobId, collectionPublic, "updated")
+	})
+
+	t.Run("OnInstallEnd with success stores log", func(t *testing.T) {
+		installOutput := "npm install successful\ninstalled 42 packages"
+		reporter.OnInstallEnd(jobId, installOutput, nil)
+
+		assertField(t, ctx, client, jobId, collectionInternal, "installLog", installOutput)
+	})
+
+	t.Run("OnInstallEnd with error marks job as failed", func(t *testing.T) {
+		testErr := errors.New("npm install failed: ENOENT package.json")
+		installOutput := "Error: cannot find package.json"
+		reporter.OnInstallEnd(jobId, installOutput, testErr)
+
+		assertField(t, ctx, client, jobId, collectionPublic, "status", db.StatusFailed)
+		assertField(t, ctx, client, jobId, collectionPublic, "error", testErr.Error())
+		assertFieldExists(t, ctx, client, jobId, collectionPublic, "completed")
+		assertField(t, ctx, client, jobId, collectionInternal, "error", testErr.Error())
+		assertField(t, ctx, client, jobId, collectionInternal, "installLog", installOutput)
+	})
 }

--- a/reporter/firestore_reporter_test.go
+++ b/reporter/firestore_reporter_test.go
@@ -25,7 +25,11 @@ func TestFirestoreReporter(t *testing.T) {
 	}
 	defer client.Close()
 
-	reporter := NewFirestoreReporter(client)
+	reporter, err := NewFirestoreReporter(client)
+	if err != nil {
+		t.Fatalf("Failed to create reporter: %v", err)
+	}
+
 	jobId := "firestore_reporter_test"
 	initialData := map[string]any{
 		"id":         jobId,

--- a/reporter/firestore_reporter_test.go
+++ b/reporter/firestore_reporter_test.go
@@ -2,7 +2,6 @@ package reporter
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/Hack4Impact-UMD/professor/db"

--- a/util/reporter.go
+++ b/util/reporter.go
@@ -1,9 +1,5 @@
 package util
 
-import (
-	"cloud.google.com/go/firestore"
-)
-
 type GradingJobReporter interface {
 	OnGradeStart(jobId string)
 	OnCloneStart(jobId string, assessmentRepo string, testRepo string)
@@ -17,8 +13,4 @@ type GradingJobReporter interface {
 	OnTestStart(jobId string, suite string, testName string)
 	OnTestEnd(jobId string, suite, testName string, passed bool, stdout, stderr string, testErrors []string, durationMs int64, err error)
 	OnTestingEnd(jobId string, err error)
-}
-
-type FirestoreReporter struct {
-	fsClient *firestore.Client
 }


### PR DESCRIPTION
```mermaid
graph TB
    User[Applicant] -->|Submits Assessment| Frontend[App Portal - Frontend]
    Frontend[App Portal - Frontend] -->|Reads Status and Results| User[Applicant]
    Frontend -->|Requests Grading| Backend[App Portal - Backend]

    Backend -->|Creates Documents| Firestore[(Firestore)]
    Backend -->|Enqueues Job| CloudTasks[Queue - Cloud Tasks]

    CloudTasks -->|Delivers Job| Professor[Professor - Cloud Run]

    Professor -->|Updates Documents| Firestore
    Professor -->|Clones Repo| GitHub[GitHub]
    Professor -->|Tests Repo| Playwright[Playwright]

    Firestore -->|Reads Documents| Frontend

    style Frontend fill:#4285f4,color:#fff
    style Backend fill:#4285f4,color:#fff
    style Professor fill:#9334e9,color:#fff
    style Firestore fill:#ffa000,color:#fff
    style CloudTasks fill:#34a853,color:#fff
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architecture section with system flow diagram to README

* **New Features**
  * Improved job lifecycle tracking with Queued, Installing, and Serving states
  * New reporter that persists grading progress, logs, and test results to Firestore

* **Bug Fixes**
  * Fixed an error log message text

* **Chores**
  * Updated ignore patterns to exclude *.log and added emulator/config and security rules

* **Tests**
  * Added integration tests validating reporter behavior and Firestore side effects
<!-- end of auto-generated comment: release notes by coderabbit.ai -->